### PR TITLE
Fix installer for Python 3.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 """PyPI Package descriptor file."""
-
-from ConfigParser import ConfigParser
+from sys import version_info
+if (version_info > (3, 0)):
+    from configparser import ConfigParser
+else:
+    from ConfigParser import ConfigParser
 from distutils.core import setup
 
 


### PR DESCRIPTION
Fixed the failure to install on Python 3.x due to the `ConfigParser` module being renamed to `configparser`. We now check the version and load the appropriate module. Closes #1.
