### PR TITLE
setup.py: Fix error with modifying setup_args list while iterating ov…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ if (version_info > (3, 0)):
     from configparser import ConfigParser
 else:
     from ConfigParser import ConfigParser
-from distutils.core import setup
+from setuptools import setup
 
 
 def get_version(change_log):
@@ -34,8 +34,8 @@ cfg = ConfigParser()
 cfg.read('setup.cfg')
 setup_args = dict(cfg.items('setup'))
 
-
-for key, val in setup_args.items():
+copy_of_setup_args = setup_args.copy()
+for key, val in copy_of_setup_args.items():
     if key.endswith('_file'):
         data = get_version(val) if key.startswith('version') else read(val)
         setup_args[key[:-5]] = data


### PR DESCRIPTION
This will fix an error in setup.py with modifying setup_args list while iterating over it. This prevents installation of the package on newer Python versions. Python 3.8 added an explicit RuntimeError for when this happens where as previous versions just allowed this.

This also replaces distutils with setuptool to get rid of error below:
"UserWarning: Unknown distribution option: 'entry_points'"

I installed with `sudo python setup.py build install` and ran an exceptionally simple test program to verify it worked.

I have virtually no knowledge of how python packaging works, etc, I just know for certain this allowed me to install the package and have my tests work.

Also, an alternative fix that might be cleaner is attached below. I can make a PR for that if preferred.
```diff
From 1a8ac66b5bc74a7338f2c85fa7f6c51f3afd104f Mon Sep 17 00:00:00 2001
From: Hiral Patel <hpatel@zoll.com>
Date: Thu, 29 Jul 2021 16:53:26 -0400
Subject: [PATCH] setup.py: Fix error with modifying setup_args list while
 iterating over it

Also replace distutils with setuptool to get rid of error below:
"UserWarning: Unknown distribution option: 'entry_points'"
---
 setup.py | 27 +++++++++++++--------------
 1 file changed, 13 insertions(+), 14 deletions(-)

diff --git a/setup.py b/setup.py
index 5644211..8cc96c2 100644
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ if (version_info > (3, 0)):
     from configparser import ConfigParser
 else:
     from ConfigParser import ConfigParser
-from distutils.core import setup
+from setuptools import setup
 
 
 def get_version(change_log):
@@ -34,21 +34,20 @@ cfg = ConfigParser()
 cfg.read('setup.cfg')
 setup_args = dict(cfg.items('setup'))
 
+setup_args["version"] = get_version(setup_args["version_file"])
+del setup_args["version_file"]
+setup_args["license"] = read(setup_args["license_file"])
+del setup_args["license_file"]
+setup_args["long_description"] = read(setup_args["long_description_file"])
+del setup_args["long_description_file"]
 
-for key, val in setup_args.items():
-    if key.endswith('_file'):
-        data = get_version(val) if key.startswith('version') else read(val)
-        setup_args[key[:-5]] = data
-        del setup_args[key]
-    elif key.endswith('_dict'):
-        data = ast.literal_eval(val)
-        setup_args[key[:-5]] = data
-        del setup_args[key]
-    elif key.endswith('_list'):
-        data = val.split()
-        setup_args[key[:-5]] = data
-        del setup_args[key]
+setup_args["entry_points"] = ast.literal_eval(setup_args["entry_points_dict"])
+del setup_args["entry_points_dict"]
 
+setup_args["py_modules"] = setup_args["py_modules_list"].split()
+del setup_args["py_modules_list"]
+setup_args["keywords"] = setup_args["keywords_list"].split()
+del setup_args["keywords_list"]
 
 if __name__ == '__main__':
     setup(**setup_args)
-- 
2.32.0

```